### PR TITLE
Allow CI publishing of CDC (with Pact) and BDC (w/ Nock).

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           [[ $PACTICIPANT = pactflow-example-consumer-nock ]] && make test_nock || make test
       - name: are pacts there?
-        run: ls ${PWD}/pacts
+        run: ls ${PWD}/src/
       - name: Publish pacts for ${{ matrix.pact_consumer }} & ${{ matrix.pact_provider }}
         run: GIT_BRANCH=${GIT_REF:11} make publish_pacts
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,10 +36,10 @@ jobs:
       - name: Install for ${{ matrix.pact_provider }}
         run: npm i
       - name: Test
-        run: [[ ${{ matrix.pact_provider }} = 'pactflow-example-consumer-nock' ]] && make test_nock || make test
         env:
           PACTICIPANT: ${{ matrix.pact_consumer }}
           PACT_PROVIDER: ${{ matrix.pact_provider }}
+        run: [[ $PACT_PROVIDER = 'pactflow-example-consumer-nock' ]] && make test_nock || make test
       - name: Publish pacts for ${{ matrix.pact_provider }}
         run: GIT_BRANCH=${GIT_REF:11} make publish_pacts
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           PACTICIPANT: ${{ matrix.pact_consumer }}
           PACT_PROVIDER: ${{ matrix.pact_provider }}
-        run: [[ $PACT_PROVIDER = 'pactflow-example-consumer-nock' ]] && make test_nock || make test
+        run: [[ $PACTICIPANT = pactflow-example-consumer-nock ]] && make test_nock || make test
       - name: Publish pacts for ${{ matrix.pact_provider }}
         run: GIT_BRANCH=${GIT_REF:11} make publish_pacts
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,6 @@ jobs:
           PACT_PROVIDER: ${{ matrix.pact_provider }}
         run: |
           [[ $PACTICIPANT = pactflow-example-consumer-nock ]] && make test_nock || make test
-      - name: echo git commit env var
-        run: echo ${GIT_COMMIT}
       - name: Publish pacts for ${{ matrix.pact_consumer }} & ${{ matrix.pact_provider }}
         run: GIT_BRANCH=${GIT_REF:11} make publish_pacts
         env:
@@ -63,12 +61,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: docker pull pactfoundation/pact-cli:latest
-      - name: echo git commit env var
-        run: echo ${GIT_COMMIT}
       - name: Can I deploy? for ${{ matrix.pact_consumer }}
         env:
           PACTICIPANT: ${{ matrix.pact_consumer }}
-        run: make can_i_deploy
+        run: GIT_BRANCH=${GIT_REF:11} make can_i_deploy
 
   # Only deploy from master
   deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,8 @@ jobs:
           PACT_PROVIDER: ${{ matrix.pact_provider }}
         run: |
           [[ $PACTICIPANT = pactflow-example-consumer-nock ]] && make test_nock || make test
-      - name: are pacts there?
-        run: ls ${PWD}/pacts
+      - name: echo git commit env var
+        run: echo ${GIT_COMMIT}
       - name: Publish pacts for ${{ matrix.pact_consumer }} & ${{ matrix.pact_provider }}
         run: GIT_BRANCH=${GIT_REF:11} make publish_pacts
         env:
@@ -63,10 +63,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: docker pull pactfoundation/pact-cli:latest
+      - name: echo git commit env var
+        run: echo ${GIT_COMMIT}
       - name: Can I deploy? for ${{ matrix.pact_consumer }}
         env:
           PACTICIPANT: ${{ matrix.pact_consumer }}
-        run: GIT_COMMIT=${GIT_COMMIT} make can_i_deploy
+        run: make can_i_deploy
 
   # Only deploy from master
   deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,9 +64,9 @@ jobs:
       - uses: actions/checkout@v2
       - run: docker pull pactfoundation/pact-cli:latest
       - name: Can I deploy? for ${{ matrix.pact_consumer }}
-        run: GIT_BRANCH=${GIT_REF:11} make can_i_deploy
         env:
           PACTICIPANT: ${{ matrix.pact_consumer }}
+        run: GIT_BRANCH=${GIT_REF:11} make can_i_deploy
 
   # Only deploy from master
   deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,7 @@ jobs:
       - name: Can I deploy? for ${{ matrix.pact_consumer }}
         env:
           PACTICIPANT: ${{ matrix.pact_consumer }}
-          GIT_COMMIT: ${{ github.sha }}
-        run: GIT_BRANCH=${GIT_REF:11} make can_i_deploy
+        run: GIT_COMMIT=${GIT_COMMIT} make can_i_deploy
 
   # Only deploy from master
   deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           [[ $PACTICIPANT = pactflow-example-consumer-nock ]] && make test_nock || make test
       - name: are pacts there?
-        run: ls ${PWD}/src/
+        run: ls ${PWD}/pacts
       - name: Publish pacts for ${{ matrix.pact_consumer }} & ${{ matrix.pact_provider }}
         run: GIT_BRANCH=${GIT_REF:11} make publish_pacts
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,40 +16,73 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pact_provider: ['pactflow-example-provider-dredd','pactflow-example-provider-restassured','pactflow-example-provider-postman', 'pactflow-example-provider']
+        pact_provider:
+          [
+            "pactflow-example-provider-dredd",
+            "pactflow-example-provider-restassured",
+            "pactflow-example-provider-postman",
+            "pactflow-example-provider",
+          ],
+        pact_consumer:
+          [
+            "pactflow-example-consumer",
+            "pactflow-example-consumer-nock"
+          ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '12'
+          node-version: "12"
       - name: Install for ${{ matrix.pact_provider }}
         run: npm i
       - name: Test
-        run: make test
+        run: [[ ${{ matrix.pact_provider }} = 'pactflow-example-consumer-nock' ]] && make test_nock || make test
         env:
+          PACTICIPANT: ${{ matrix.pact_consumer }}
           PACT_PROVIDER: ${{ matrix.pact_provider }}
       - name: Publish pacts for ${{ matrix.pact_provider }}
         run: GIT_BRANCH=${GIT_REF:11} make publish_pacts
         env:
+          PACTICIPANT: ${{ matrix.pact_consumer }}
           PACT_PROVIDER: ${{ matrix.pact_provider }}
 
   # Runs on branches as well, so we know the status of our PRs
   can-i-deploy:
     runs-on: ubuntu-latest
     needs: test
+    strategy:
+      matrix:
+        pact_consumer:
+          [
+            "pactflow-example-consumer",
+            "pactflow-example-consumer-nock"
+          ]
     steps:
       - uses: actions/checkout@v2
       - run: docker pull pactfoundation/pact-cli:latest
       - name: Can I deploy?
         run: GIT_BRANCH=${GIT_REF:11} make can_i_deploy
+        env:
+          PACTICIPANT: ${{ matrix.pact_consumer }}
+          PACT_PROVIDER: ${{ matrix.pact_provider }}
 
   # Only deploy from master
   deploy:
     runs-on: ubuntu-latest
     needs: can-i-deploy
+    strategy:
+      matrix:
+        pact_consumer:
+          [
+            "pactflow-example-consumer",
+            "pactflow-example-consumer-nock"
+          ]
     steps:
       - uses: actions/checkout@v2
       - run: docker pull pactfoundation/pact-cli:latest
       - name: Deploy
         run: GIT_BRANCH=${GIT_REF:11} make deploy
         if: github.ref == 'refs/heads/master'
+        env:
+          PACTICIPANT: ${{ matrix.pact_consumer }}
+          PACT_PROVIDER: ${{ matrix.pact_provider }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Can I deploy? for ${{ matrix.pact_consumer }}
         env:
           PACTICIPANT: ${{ matrix.pact_consumer }}
+          GIT_COMMIT: ${{ github.sha }}
         run: GIT_BRANCH=${GIT_REF:11} make can_i_deploy
 
   # Only deploy from master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,9 @@ jobs:
         pact_provider:
           [
             "pactflow-example-provider-dredd",
-            # "pactflow-example-provider-restassured",
-            # "pactflow-example-provider-postman",
-            # "pactflow-example-provider",
+            "pactflow-example-provider-restassured",
+            "pactflow-example-provider-postman",
+            "pactflow-example-provider",
           ]
         pact_consumer:
           [

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 env:
   PACT_BROKER_BASE_URL: https://testdemo.pactflow.io
   PACT_BROKER_TOKEN: ${{ secrets.PACTFLOW_TOKEN_FOR_CI_CD_WORKSHOP }}
-  REACT_APP_API_BASE_URL: http://localhost:8080
+  REACT_APP_API_BASE_URL: http://localhost:3001
   GIT_COMMIT: ${{ github.sha }}
   GIT_REF: ${{ github.ref }}
 
@@ -41,6 +41,8 @@ jobs:
           PACT_PROVIDER: ${{ matrix.pact_provider }}
         run: |
           [[ $PACTICIPANT = pactflow-example-consumer-nock ]] && make test_nock || make test
+      - name: are pacts there?
+        run: ls ${PWD}/pacts
       - name: Publish pacts for ${{ matrix.pact_consumer }} & ${{ matrix.pact_provider }}
         run: GIT_BRANCH=${GIT_REF:11} make publish_pacts
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,8 @@ jobs:
         env:
           PACTICIPANT: ${{ matrix.pact_consumer }}
           PACT_PROVIDER: ${{ matrix.pact_provider }}
-        run: [[ $PACTICIPANT = pactflow-example-consumer-nock ]] && make test_nock || make test
+        run: |
+          [[ $PACTICIPANT = pactflow-example-consumer-nock ]] && make test_nock || make test
       - name: Publish pacts for ${{ matrix.pact_provider }}
         run: GIT_BRANCH=${GIT_REF:11} make publish_pacts
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
             "pactflow-example-provider-restassured",
             "pactflow-example-provider-postman",
             "pactflow-example-provider",
-          ],
+          ]
         pact_consumer:
           [
             "pactflow-example-consumer",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
             "pactflow-example-provider-dredd",
             "pactflow-example-provider-restassured",
             "pactflow-example-provider-postman",
-            "pactflow-example-provider",
+            # "pactflow-example-provider",
           ]
         pact_consumer:
           [

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,15 +33,15 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: "12"
-      - name: Install for ${{ matrix.pact_provider }}
+      - name: Install for ${{ matrix.pact_consumer }} & ${{ matrix.pact_provider }}
         run: npm i
-      - name: Test
+      - name: Test for ${{ matrix.pact_consumer }} & ${{ matrix.pact_provider }}
         env:
           PACTICIPANT: ${{ matrix.pact_consumer }}
           PACT_PROVIDER: ${{ matrix.pact_provider }}
         run: |
           [[ $PACTICIPANT = pactflow-example-consumer-nock ]] && make test_nock || make test
-      - name: Publish pacts for ${{ matrix.pact_provider }}
+      - name: Publish pacts for ${{ matrix.pact_consumer }} & ${{ matrix.pact_provider }}
         run: GIT_BRANCH=${GIT_REF:11} make publish_pacts
         env:
           PACTICIPANT: ${{ matrix.pact_consumer }}
@@ -61,11 +61,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: docker pull pactfoundation/pact-cli:latest
-      - name: Can I deploy?
+      - name: Can I deploy? for ${{ matrix.pact_consumer }}
         run: GIT_BRANCH=${GIT_REF:11} make can_i_deploy
         env:
           PACTICIPANT: ${{ matrix.pact_consumer }}
-          PACT_PROVIDER: ${{ matrix.pact_provider }}
 
   # Only deploy from master
   deploy:
@@ -81,9 +80,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: docker pull pactfoundation/pact-cli:latest
-      - name: Deploy
+      - name: Deploy for ${{ matrix.pact_consumer }} 
         run: GIT_BRANCH=${GIT_REF:11} make deploy
         if: github.ref == 'refs/heads/master'
         env:
           PACTICIPANT: ${{ matrix.pact_consumer }}
-          PACT_PROVIDER: ${{ matrix.pact_provider }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,9 @@ jobs:
         pact_provider:
           [
             "pactflow-example-provider-dredd",
-            "pactflow-example-provider-restassured",
-            "pactflow-example-provider-postman",
-            "pactflow-example-provider",
+            # "pactflow-example-provider-restassured",
+            # "pactflow-example-provider-postman",
+            # "pactflow-example-provider",
           ]
         pact_consumer:
           [

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,14 @@ no_deploy:
 can_i_deploy: .env
 	@echo "\n========== STAGE: can-i-deploy? ==========\n"
 	@echo ${GIT_COMMIT} 
+	@echo ${GIT_BRANCH} 
+	@echo ${PACTICIPANT} 
+	@echo broker can-i-deploy \
+	  --pacticipant ${PACTICIPANT} \
+	  --version ${GIT_COMMIT} \
+	  --to-environment production \
+	  --retry-while-unknown 0 \
+	  --retry-interval 10
 	@"${PACT_CLI}" broker can-i-deploy \
 	  --pacticipant ${PACTICIPANT} \
 	  --version ${GIT_COMMIT} \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Default to the read only token - the read/write token will be present on Travis CI.
 # It's set as a secure environment variable in the .travis.yml file
 GITHUB_ORG="pactflow"
-PACTICIPANT := "pactflow-example-consumer"
+PACTICIPANT := ${PACTICIPANT} || "pactflow-example-consumer"
 GITHUB_WEBHOOK_UUID := "04510dc1-7f0a-4ed2-997d-114bfa86f8ad"
 PACT_CHANGED_WEBHOOK_UUID := "8e49caaa-0498-4cc1-9368-325de0812c8a"
 PACT_CLI="docker run --rm -v ${PWD}:${PWD} -e PACT_BROKER_BASE_URL -e PACT_BROKER_TOKEN pactfoundation/pact-cli"

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ no_deploy:
 
 can_i_deploy: .env
 	@echo "\n========== STAGE: can-i-deploy? ==========\n"
+	@echo ${GIT_COMMIT} 
 	@"${PACT_CLI}" broker can-i-deploy \
 	  --pacticipant ${PACTICIPANT} \
 	  --version ${GIT_COMMIT} \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Default to the read only token - the read/write token will be present on Travis CI.
 # It's set as a secure environment variable in the .travis.yml file
 GITHUB_ORG="pactflow"
-PACTICIPANT := ${PACTICIPANT} || "pactflow-example-consumer"
+PACTICIPANT ?= ${PACTICIPANT} || "pactflow-example-consumer"
 GITHUB_WEBHOOK_UUID := "04510dc1-7f0a-4ed2-997d-114bfa86f8ad"
 PACT_CHANGED_WEBHOOK_UUID := "8e49caaa-0498-4cc1-9368-325de0812c8a"
 PACT_CLI="docker run --rm -v ${PWD}:${PWD} -e PACT_BROKER_BASE_URL -e PACT_BROKER_TOKEN pactfoundation/pact-cli"
@@ -41,6 +41,7 @@ fake_ci_nock: .env
 	GIT_COMMIT=`git rev-parse --short HEAD`+`date +%s` \
 	GIT_BRANCH=`git rev-parse --abbrev-ref HEAD` \
 	REACT_APP_API_BASE_URL=http://localhost:8080 \
+	PACTICIPANT=pactflow-example-consumer-nock \
 	make ci_nock
 
 publish_pacts: .env
@@ -57,7 +58,7 @@ test: .env
 
 test_nock: .env
 	@echo "\n========== STAGE: test (nock) ==========\n"
-	npm run test:nock
+	PACTICIPANT=pactflow-example-consumer-nock npm run test:nock
 
 ## =====================
 ## Deploy tasks
@@ -73,21 +74,12 @@ no_deploy:
 
 can_i_deploy: .env
 	@echo "\n========== STAGE: can-i-deploy? ==========\n"
-	@echo ${GIT_COMMIT} 
-	@echo ${GIT_BRANCH} 
-	@echo ${PACTICIPANT} 
-	@echo broker can-i-deploy \
-	  --version '${GIT_COMMIT}' \
-	  --to-environment production \
-	  --retry-while-unknown 0 \
-	  --retry-interval 10 \
-	  --pacticipant ${PACTICIPANT}
 	@"${PACT_CLI}" broker can-i-deploy \
-	  --version '${GIT_COMMIT}' \
+	  --pacticipant ${PACTICIPANT} \
+	  --version ${GIT_COMMIT} \
 	  --to-environment production \
 	  --retry-while-unknown 0 \
-	  --retry-interval 10 \
-	  --pacticipant ${PACTICIPANT}
+	  --retry-interval 10
 
 deploy_app:
 	@echo "\n========== STAGE: deploy ==========\n"

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test: .env
 
 test_nock: .env
 	@echo "\n========== STAGE: test (nock) ==========\n"
-	npm run test:nock
+	PACTICIPANT=${PACTICIPANT_NOCK} npm run test:nock
 
 ## =====================
 ## Deploy tasks

--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,13 @@ can_i_deploy: .env
 	@echo ${GIT_BRANCH} 
 	@echo ${PACTICIPANT} 
 	@echo broker can-i-deploy \
-	  --version ${GIT_COMMIT} \
+	  --version '${GIT_COMMIT}' \
 	  --to-environment production \
 	  --retry-while-unknown 0 \
 	  --retry-interval 10 \
 	  --pacticipant ${PACTICIPANT}
 	@"${PACT_CLI}" broker can-i-deploy \
-	  --version ${GIT_COMMIT} \
+	  --version '${GIT_COMMIT}' \
 	  --to-environment production \
 	  --retry-while-unknown 0 \
 	  --retry-interval 10 \

--- a/Makefile
+++ b/Makefile
@@ -74,11 +74,11 @@ no_deploy:
 can_i_deploy: .env
 	@echo "\n========== STAGE: can-i-deploy? ==========\n"
 	@"${PACT_CLI}" broker can-i-deploy \
+	  --pacticipant ${PACTICIPANT} \
 	  --version ${GIT_COMMIT} \
 	  --to-environment production \
 	  --retry-while-unknown 0 \
-	  --retry-interval 10 \
-	  --pacticipant ${PACTICIPANT}
+	  --retry-interval 10
 
 deploy_app:
 	@echo "\n========== STAGE: deploy ==========\n"

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test: .env
 
 test_nock: .env
 	@echo "\n========== STAGE: test (nock) ==========\n"
-	PACTICIPANT=${PACTICIPANT_NOCK} npm run test:nock
+	npm run test:nock
 
 ## =====================
 ## Deploy tasks

--- a/Makefile
+++ b/Makefile
@@ -77,17 +77,17 @@ can_i_deploy: .env
 	@echo ${GIT_BRANCH} 
 	@echo ${PACTICIPANT} 
 	@echo broker can-i-deploy \
-	  --pacticipant ${PACTICIPANT} \
 	  --version ${GIT_COMMIT} \
 	  --to-environment production \
 	  --retry-while-unknown 0 \
-	  --retry-interval 10
+	  --retry-interval 10 \
+	  --pacticipant ${PACTICIPANT}
 	@"${PACT_CLI}" broker can-i-deploy \
-	  --pacticipant ${PACTICIPANT} \
 	  --version ${GIT_COMMIT} \
 	  --to-environment production \
 	  --retry-while-unknown 0 \
-	  --retry-interval 10
+	  --retry-interval 10 \
+	  --pacticipant ${PACTICIPANT}
 
 deploy_app:
 	@echo "\n========== STAGE: deploy ==========\n"

--- a/Makefile
+++ b/Makefile
@@ -74,11 +74,11 @@ no_deploy:
 can_i_deploy: .env
 	@echo "\n========== STAGE: can-i-deploy? ==========\n"
 	@"${PACT_CLI}" broker can-i-deploy \
-	  --pacticipant ${PACTICIPANT} \
 	  --version ${GIT_COMMIT} \
 	  --to-environment production \
 	  --retry-while-unknown 0 \
-	  --retry-interval 10
+	  --retry-interval 10 \
+	  --pacticipant ${PACTICIPANT}
 
 deploy_app:
 	@echo "\n========== STAGE: deploy ==========\n"

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ To be able to run some of the commands locally, you will need to export the foll
 
 NOTE: The nock recordings are already in the project, in the `./fixtures` directory, see below for how to obtain these recordings.
 
-Set PACTICIPANT=
 * `make clean` - ensure previous pacts are cleared
 * `make test_nock` - run the nock test locally
 * `make fake_ci_nock` - run the nock version of the CI process locally

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ To be able to run some of the commands locally, you will need to export the foll
 
 NOTE: The nock recordings are already in the project, in the `./fixtures` directory, see below for how to obtain these recordings.
 
+Set PACTICIPANT=
 * `make clean` - ensure previous pacts are cleared
 * `make test_nock` - run the nock test locally
 * `make fake_ci_nock` - run the nock version of the CI process locally

--- a/src/api.record.spec.js
+++ b/src/api.record.spec.js
@@ -29,7 +29,7 @@ export const convertNockToPact = () => {
   const scopes = require(path.join(__dirname, "..", nockBack.fixtures, filename))
 
   const pact = {
-    consumer: { name: "pactflow-example-consumer" },
+    consumer: { name: "pactflow-example-consumer-nock" },
     provider: { name: process.env.PACT_PROVIDER ? process.env.PACT_PROVIDER : 'pactflow-example-provider' },
     interactions: [],
     metadata: {

--- a/src/api.record.spec.js
+++ b/src/api.record.spec.js
@@ -4,33 +4,40 @@ import * as fs from "fs";
 
 const nockBack = require("nock").back;
 nockBack.setMode("record"); // record interactions
-nockBack.fixtures = "fixtures" // fixture files will be stored in ./fixtures/<fixture>.json
-const filename = "nock.json"
+nockBack.fixtures = "fixtures"; // fixture files will be stored in ./fixtures/<fixture>.json
+const filename = "nock.json";
 
 describe("API Nock Tests", () => {
   test("nock recordings", () => {
     // recording of the fixture
-    return nockBack(filename).then(
-      async ({ nockDone }) => {
-        const api = new API("http://localhost:3001");
+    return nockBack(filename).then(async ({ nockDone }) => {
+      const api = new API("http://localhost:3001");
 
-        // Record all of the data
-        await api.getAllProducts();
-        await api.getProduct("10");
+      // Record all of the data
+      await api.getAllProducts();
+      await api.getProduct("10");
 
-        nockDone();
-      }
-    );
+      nockDone();
+    });
   });
 });
 
 // Crude converter from a nock fixture to a pactfile
 export const convertNockToPact = () => {
-  const scopes = require(path.join(__dirname, "..", nockBack.fixtures, filename))
+  const scopes = require(path.join(
+    __dirname,
+    "..",
+    nockBack.fixtures,
+    filename
+  ));
 
   const pact = {
     consumer: { name: "pactflow-example-consumer-nock" },
-    provider: { name: process.env.PACT_PROVIDER ? process.env.PACT_PROVIDER : 'pactflow-example-provider-dredd' },
+    provider: {
+      name: process.env.PACT_PROVIDER
+        ? process.env.PACT_PROVIDER
+        : "pactflow-example-provider-dredd",
+    },
     interactions: [],
     metadata: {
       pactSpecification: {
@@ -55,15 +62,15 @@ export const convertNockToPact = () => {
   });
 
   try {
-    fs.mkdirSync(path.join(__dirname, "..", 'pacts'))
-
+    fs.mkdirSync(path.join(__dirname, "..", "pacts"));
+  } catch (e) {
+    // writeFileSync fails if dir doesnt exist
+    // mkdirSync fails if dir exists
   }
-  catch(e){
+  fs.writeFileSync(
+    path.join(__dirname, "..", "pacts", "nock-contract.json"),
+    JSON.stringify(pact)
+  );
 
-  }
-  fs.writeFileSync(path.join(__dirname, "..", 'pacts', 'nock-contract.json'), JSON.stringify(pact));
-  
   return scopes;
 };
-
-

--- a/src/api.record.spec.js
+++ b/src/api.record.spec.js
@@ -30,7 +30,7 @@ export const convertNockToPact = () => {
 
   const pact = {
     consumer: { name: "pactflow-example-consumer-nock" },
-    provider: { name: process.env.PACT_PROVIDER ? process.env.PACT_PROVIDER : 'pactflow-example-provider' },
+    provider: { name: process.env.PACT_PROVIDER ? process.env.PACT_PROVIDER : 'pactflow-example-provider-dredd' },
     interactions: [],
     metadata: {
       pactSpecification: {
@@ -54,7 +54,13 @@ export const convertNockToPact = () => {
     };
   });
 
-  fs.mkdirSync(path.join(__dirname, "..", 'pacts'))
+  try {
+    fs.mkdirSync(path.join(__dirname, "..", 'pacts'))
+
+  }
+  catch(e){
+
+  }
   fs.writeFileSync(path.join(__dirname, "..", 'pacts', 'nock-contract.json'), JSON.stringify(pact));
   
   return scopes;

--- a/src/api.record.spec.js
+++ b/src/api.record.spec.js
@@ -54,6 +54,10 @@ export const convertNockToPact = () => {
     };
   });
 
-  fs.writeFileSync("./pacts/nock-contract.json", JSON.stringify(pact));
+  fs.mkdirSync(path.join(__dirname, "..", 'pacts'))
+  fs.writeFileSync(path.join(__dirname, "..", 'pacts', 'nock-contract.json'), JSON.stringify(pact));
+  
   return scopes;
 };
+
+


### PR DESCRIPTION
- Creates matrix in GH to test against the two consumer examples in this project (regular pact, and via BYO tool Nock
- Makes provisions to allow for testing locally to set correct PACTICIPANT (defaults to `pactflow-example-consumer` not to disrupt existing workflows
