### PR TITLE
feat: enable pactflow-example-provider

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
             "pactflow-example-provider-dredd",
             "pactflow-example-provider-restassured",
             "pactflow-example-provider-postman",
-            # "pactflow-example-provider",
+            "pactflow-example-provider",
           ]
         pact_consumer:
           [


### PR DESCRIPTION
This repo contains

pactflow-example-consumer generating Pact files via pact-js
pactflow-example-consumer-nock generating Pact files via nock and an adapter

The results are below.

|  consumer | provider  |  verification type  | result  |
|---|---|---|---|
| pactflow-example-consumer | pactflow-example-provider  |  CDCT  | ✅  |
| pactflow-example-consumer | pactflow-example-provider-dredd  |  BDCT | ✅  |
| pactflow-example-consumer | pactflow-example-provider-restassured  | BDCT | ✅  |
| pactflow-example-consumer | pactflow-example-provider-postman  | BDCT | ✅  |
| pactflow-example-consumer-nock  | pactflow-example-provider  | CDCT | [✖︎](https://github.com/pactflow/example-provider/runs/5794359257?check_suite_focus=true)  |
| pactflow-example-consumer-nock  | pactflow-example-provider-dredd   | BDCT  | ✅  |
| pactflow-example-consumer-nock  | pactflow-example-provider-restassured   |  BDCT |  ✅ |
| pactflow-example-consumer-nock  | pactflow-example-provider-postman  | BDCT  | ✅  |

Couple of questions/thoughts

1. Should we split out the example-provider and example-provider-nock
2. Should we keep them in the same, but exclude the `pactflow-example-consumer-nock`-`pactflow-example-provider` test run from happening
3. Could the example-provider support CDCT verification, and BDCT verification with `OAS`
  - It uploads an OAS spec
  - In the triggered provider verification step, it can hold a list of providers that use BDCT or need CDCT provider states?
  
  I love the idea of having our test builds for the example consumers, testing against as many of the combinations as they can, in order to test and showcase the interchangeability 