### PR TITLE
chore: branch over tag, rm PACT_CHANGED_WEBHOOK_UUID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@
 GITHUB_ORG="pactflow"
 PACTICIPANT="pactflow-example-consumer"
 GITHUB_WEBHOOK_UUID := "04510dc1-7f0a-4ed2-997d-114bfa86f8ad"
-PACT_CHANGED_WEBHOOK_UUID := "8e49caaa-0498-4cc1-9368-325de0812c8a"
 PACT_CLI="docker run --rm -v ${PWD}:${PWD} -e PACT_BROKER_BASE_URL -e PACT_BROKER_TOKEN pactfoundation/pact-cli"
 
 # Only deploy from master

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The project uses a Makefile to simulate a very simple build pipeline with two st
 
 * Test
   * Run tests (including the pact tests that generate the contract)
-  * Publish pacts, tagging the consumer version with the name of the current branch
+  * Publish pacts, associating the consumer version with the name of the current branch
   * Check if we are safe to deploy to prod (ie. has the pact content been successfully verified)
 * Deploy (only from master)
   * Deploy app (just pretend for the purposes of this example!)

--- a/pactflow/github-commit-status-webhook.json
+++ b/pactflow/github-commit-status-webhook.json
@@ -1,6 +1,6 @@
 {
   "state": "${pactbroker.githubVerificationStatus}",
   "description": "Pact Verification Tests",
-  "context": "${pactbroker.providerName} ${pactbroker.providerVersionTags}",
+  "context": "${pactbroker.providerName} ${pactbroker.providerVersionBranch}",
   "target_url": "${pactbroker.verificationResultUrl}"
 }


### PR DESCRIPTION
- PACT_CHANGED_WEBHOOK_UUID doesn't seem relevant on the consumer side, at least there is nothing in the `Makefile` to make use of it.
- Dropped last mention of tag in readme
- updated GH commit status webhook `providerVersionBranch ` as per https://github.com/pact-foundation/pact_broker/blob/master/lib/pact_broker/doc/views/webhooks.markdown#dynamic-variable-substitution


Legacy codebase for tags / pact_changed workflow https://github.com/pactflow/example-consumer-legacy