### PR TITLE
test: Give the different requests different uponReceiving strings

### DIFF
--- a/src/api.pact.spec.js
+++ b/src/api.pact.spec.js
@@ -27,7 +27,7 @@ describe('API Pact test', () => {
 
       mockProvider
         .given('a product with ID 10 exists')
-        .uponReceiving('a request to get a product')
+        .uponReceiving('a request to get a product with ID=10')
         .withRequest({
           method: 'GET',
           path: '/product/10',
@@ -58,7 +58,7 @@ describe('API Pact test', () => {
 
       mockProvider
         .given('a product with ID 11 does not exist')
-        .uponReceiving('a request to get a product')
+        .uponReceiving('a request to get a product with ID=11')
         .withRequest({
           method: 'GET',
           path: '/product/11',


### PR DESCRIPTION
This is required as otherwise the two interactions will clobber each other.