### PR TITLE
fix: simplify PACT_PROVIDER env variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   PACT_BROKER_BASE_URL: ${{ secrets.PACT_BROKER_BASE_URL }}
-  PACT_PROVIDER: ${{ secrets.PACT_PROVIDER }}
+  PACT_PROVIDER: pactflow-example-provider
   PACT_BROKER_TOKEN: ${{ secrets.PACTFLOW_TOKEN_FOR_CI_CD_WORKSHOP }}
   REACT_APP_API_BASE_URL: http://localhost:3001
   GIT_COMMIT: ${{ github.sha }}
@@ -15,14 +15,6 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        pact_provider: [
-            # "pactflow-example-bi-directional-provider-dredd",
-            # "pactflow-example-bi-directional-provider-restassured",
-            # "pactflow-example-bi-directional-provider-postman",
-            'pactflow-example-provider'
-          ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -32,12 +24,12 @@ jobs:
         run: npm i
       - name: Test
         env:
-          PACT_PROVIDER: ${{ matrix.pact_provider }}
+          PACT_PROVIDER: ${{ env.PACT_PROVIDER }}
         run: make test
-      - name: Publish pacts between pactflow-example-consumer and ${{ matrix.pact_provider }}
+      - name: Publish pacts between pactflow-example-consumer and ${{ env.PACT_PROVIDER }}
         run: GIT_BRANCH=${GIT_REF:11} make publish_pacts
         env:
-          PACT_PROVIDER: ${{ matrix.pact_provider }}
+          PACT_PROVIDER: ${{ env.PACT_PROVIDER }}
 
   # Runs on branches as well, so we know the status of our PRs
   can-i-deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   PACT_BROKER_BASE_URL: ${{ secrets.PACT_BROKER_BASE_URL }}
-  PACT_PROVIDER: ${{ env.PACT_PROVIDER }}
+  PACT_PROVIDER: ${{ secrets.PACT_PROVIDER }}
   PACT_BROKER_TOKEN: ${{ secrets.PACTFLOW_TOKEN_FOR_CI_CD_WORKSHOP }}
   REACT_APP_API_BASE_URL: http://localhost:3001
   GIT_COMMIT: ${{ github.sha }}


### PR DESCRIPTION
The build was broken [here](https://github.com/pactflow/example-consumer/actions/runs/6349920973) due to the reference to env. As suggested by Yousaf, I will replace `matrix.pact_provider` with `env.PACT_PROVIDER`