### PR TITLE
feat: add docker compose example for pact consumer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+ARG NODE_VERSION=20.11
+
+FROM node:${NODE_VERSION}
+
+WORKDIR /test
+
+COPY package.json package.json
+COPY package-lock.json package-lock.json
+COPY .env .env
+COPY Makefile Makefile
+RUN  npm install
+
+COPY src src
+# Allow github actions to write to this directory
+RUN mkdir pacts
+RUN chmod 777 pacts
+
+ENV  HOME /home/node
+USER node
+
+
+CMD ["make", "test"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.6'
+services:
+  example-consumer:
+    build:
+      context: ./
+    environment:
+      REACT_APP_API_BASE_URL: http://localhost:8080
+    volumes:
+      - pacts_data:/test/pacts
+    # command: tail -f /dev/null
+    command: make test
+    platform: linux/amd64
+
+  pact-broker-cli:
+    image: pactfoundation/pact-cli:latest-multi
+    platform: linux/amd64
+    depends_on:
+      - example-consumer
+    environment:
+      PACT_BROKER_BASE_URL: ${PACT_BROKER_BASE_URL}
+      PACT_BROKER_TOKEN: ${PACT_BROKER_TOKEN}
+      PACT_CONSUMER_BRANCH: ${PACT_CONSUMER_BRANCH}
+      PACT_CONSUMER_APP_VERSION: ${PACT_CONSUMER_APP_VERSION}
+    volumes:
+      - pacts_data:/pact/pacts
+    # command: tail -f /dev/null
+    command: |
+      pact-broker publish pacts --branch=$PACT_CONSUMER_BRANCH --consumer-app-version=$PACT_CONSUMER_APP_VERSION
+
+volumes:
+  pacts_data:


### PR DESCRIPTION
This is a work in progress, trying to demonstrate the error I'm getting when working with docker compose and pact:

```
The pact core was unable to write the pact file
```

So far I'm not able to reproduce it; the docker volume `pacts_data` is being read just fine by both the example-consumer and pact-cli containers. Not sure how to fix it on my end.